### PR TITLE
Move training to inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Working Groups store these artifacts, including meeting notes, in this repositor
 
 | Working Group      | Objectives    |
 | ------------------ | ------------- |
-| [Training](https://lfaifoundation.slack.com/archives/C018K560U14) | Expand ONNX to support training as well as inference |
 | [Preprocessing](https://lfaifoundation.slack.com/archives/C02AANGFBJB) | Data pre/post processing and featurization |
 
 ## Completed working groups
@@ -37,3 +36,4 @@ Working Groups store these artifacts, including meeting notes, in this repositor
 | [Testing/Compliance](https://gitter.im/onnx/test_compliance) | Create tools, tests and APIs to ensure models and backends comply with the ONNX specification | became part of the ArchInfra SIG for now |
 | [Edge/Mobile](https://gitter.im/onnx/edge) | Enable deployment of ONNX models to edge platforms by identifying the ONNX operators that must be supported by mobile and IoT runtimes, defining tool chain requirements, and contributing to ONNX compatibility tests | Stopped as of January 2020 |
 | [Data Pipelines](https://gitter.im/onnx/pipelines) | Define new operators for processing the data that goes in and comes out | No recent activity |
+| [Training](https://lfaifoundation.slack.com/archives/C018K560U14) | Expand ONNX to support training as well as inference |


### PR DESCRIPTION
probably not active https://github.com/onnx/steering-committee/blob/main/meeting-notes/2023/20230301.md

=> would move it again to active list, when there is some activity. 